### PR TITLE
use selected text to look up if that is the case

### DIFF
--- a/app/src/main/java/io/github/ichisadashioko/android/kanji/MainActivity.java
+++ b/app/src/main/java/io/github/ichisadashioko/android/kanji/MainActivity.java
@@ -505,7 +505,9 @@ public class MainActivity extends Activity implements TouchCallback
         saveWritingHistory(textRenderer.getText().toString());
     }
 
-    /** Clear text showing in the UI. */
+    /**
+     * Clear text showing in the UI.
+     */
     public void clearText(View view)
     {
         saveWritingHistory(textRenderer.getText().toString());
@@ -595,11 +597,21 @@ public class MainActivity extends Activity implements TouchCallback
     public void lookUpMeaningWithJishoDotOrg(View view)
     {
         String japaneseText = this.textRenderer.getText().toString();
-        System.out.println("Text to be looked up: " + japaneseText);
         if (!japaneseText.isEmpty())
         {
             saveWritingHistory(japaneseText);
 
+            int selectionStart = this.textRenderer.getSelectionStart();
+            int selectionEnd   = this.textRenderer.getSelectionEnd();
+
+            System.out.println("selectionStart: " + selectionStart);
+            System.out.println("selectionEnd: " + selectionEnd);
+            if ((selectionEnd - selectionStart) > 0)
+            {
+                japaneseText = japaneseText.substring(selectionStart, selectionEnd);
+            }
+
+            System.out.println("Text to be looked up: " + japaneseText);
             try
             {
                 String encodedText = URLEncoder.encode(japaneseText, "utf-8");


### PR DESCRIPTION
When we use the app to write a long line (e.g. `先輩は初めてのクレーンゲームに奮闘している`), there is only some words we want to look up because we may understand most of the sentence but there is a new word we don't know (e.g. `奮闘`). We want to look up that word but we don't want to delete the sentence to leave that only words there because there might be other words in the sentence we want to look up later.

The PR adds a feature that allows user to select a word and press the search icon to look up that word only. If there is no selection, we will keep look up the whole text content in the text field as before.