### PR TITLE
Fix CI NDK version

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,8 +15,17 @@ jobs:
       with:
         java-version: 1.8
 
-    - name: locate sdkmanager
-      run: which sdkmanager
+    - name: install linux tools
+      run: sudo apt install -y tree wget unzip
+
+    - name: download android ndk 20
+      run: wget https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
+
+    - name: unzip ndk
+      run: unzip android-ndk-r20b-linux-x86_64.zip
+
+    - name: show directory structure
+      run: tree .
 
     - name: Locate Gradle
       run: which gradle
@@ -26,12 +35,6 @@ jobs:
 
     - name: Build project
       run: bash ./gradlew build
-
-    - name: Install tree
-      run: sudo apt install -y tree
-
-    - name: Show directory structure
-      run: tree .
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -16,13 +16,16 @@ jobs:
         java-version: 1.8
 
     - name: install linux tools
-      run: sudo apt install -y tree wget unzip
+      run: sudo apt install -y tree wget unzip python3
 
     - name: download android ndk 20
       run: wget https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
 
     - name: unzip ndk
       run: unzip android-ndk-r20b-linux-x86_64.zip
+
+    - name: setup ndk.dir for gradle
+      run: python3 setup_ndk_linux.py
 
     - name: show directory structure
       run: tree .

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,6 +15,9 @@ jobs:
       with:
         java-version: 1.8
 
+    - name: locate sdkmanager
+      run: which sdkmanager
+
     - name: Locate Gradle
       run: which gradle
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,4 +41,4 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        path: .
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/setup_ndk_linux.py
+++ b/setup_ndk_linux.py
@@ -3,7 +3,7 @@
 import os
 
 if __name__ == '__main__':
-    ndk_filepath = 'android-ndk-r20b-linux-x86_64'
+    ndk_filepath = 'android-ndk-r20b'
     if not os.path.exists(ndk_filepath):
         raise Exception(ndk_filepath + ' does not exist!')
 

--- a/setup_ndk_linux.py
+++ b/setup_ndk_linux.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# encoding=utf-8
+import os
+
+if __name__ == '__main__':
+    ndk_filepath = 'android-ndk-r20b-linux-x86_64'
+    if not os.path.exists(ndk_filepath):
+        raise Exception(ndk_filepath + ' does not exist!')
+
+    ndk_filepath = os.path.abspath(ndk_filepath)
+
+    gradle_props_filepath = 'local.properties'
+
+    content = ''
+
+    if os.path.exists(gradle_props_filepath):
+        content = open(gradle_props_filepath, mode='rb').read().decode('utf-8')
+
+    if len(content) > 0:
+        if content[-1] == '\n':
+            content = content + 'ndk.dir=' + ndk_filepath + '\n'
+        else:
+            content = content + '\nndk.dir=' + ndk_filepath + '\n'
+    else:
+        content = 'ndk.dir=' + ndk_filepath + '\n'
+
+    open(gradle_props_filepath, mode='wb').write(content.encode('utf-8'))


### PR DESCRIPTION
Github Actions CI agent only has NDK version 21 (at the time of writing). However, the `tensorflow-lite` libraries require NDK version 20 in order to build. We have to manually download the NDK version 20, unzip it to a directory and set the `ndk.dir` property in the `local.properties` file at the project root directory.

https://stackoverflow.com/a/42348276/8364403